### PR TITLE
Switch to new hostname of the TNS

### DIFF
--- a/frbcat/tns.py
+++ b/frbcat/tns.py
@@ -174,7 +174,7 @@ class TNS():
         # Loop through pages on TNS webpage till no more results
         while more:
             # Limit results to frbs
-            url = 'https://wis-tns.weizmann.ac.il/search?&include_frb=1'
+            url = 'https://www.wis-tns.org/search?&include_frb=1'
             url += '&objtype%5B%5D=130&num_page=' + str(page_length) + '&page='
             url += str(page)
 

--- a/frbcat/tns.py
+++ b/frbcat/tns.py
@@ -353,8 +353,8 @@ class TNS():
         err[err == ''] = np.nan
         df['burst_bandwidth_err'] = err.astype(float)
 
-        for c in ('ref_freq', 'inst_bandwidth'):
-            df[c] = df[c].str.strip(' MHz').astype(float)
+        #for c in ('ref_freq', 'inst_bandwidth'):
+        #    df[c] = df[c].str.strip(' MHz').astype(float)
 
         s = 'sampling_time'
         df[s] = df[s].str.strip(' ms').astype(float)


### PR DESCRIPTION
Hi David,

Here is a simple fix that switches to the new hostname of the TNS. This fixes a certificate issue when trying to retrieve the data from the server.

OK?

Cheers.
Fabian